### PR TITLE
Check if window is undefined

### DIFF
--- a/src/store/worker-store.ts
+++ b/src/store/worker-store.ts
@@ -12,7 +12,7 @@ import {FuncFilter} from '../filter-json/func-filter';
 let msgid = 0;
 let worker: Worker;
     
-if (window.Worker) {
+if (typeof window !== 'undefined' && window.Worker) {
   worker = new window.Worker(codeToBlob(WorkerCode as any)); // 使用 blob对象的url
 }
  


### PR DESCRIPTION
In next.js packages are loaded server side and client side. On the server window doesn't exist and next,js will throws an error when trying to build.

This change fixes that by checking if `typeof window !== 'undefined'`. Note that this package still won't function properly on the server, but it this change does allow importing the package in next.js without blowing up. That is, this code now works in next.js, where previously there'd be a compilation error:

```
import Logger from 'idb-logger'

let logger = null
if (typeof window !== 'undefined') {
  logger = new Logger()
}

export default logger
```